### PR TITLE
FLOW-1904 - Removing unnecessary throw

### DIFF
--- a/src/main/java/com/manywho/services/identity/authentication/AuthenticationRepository.java
+++ b/src/main/java/com/manywho/services/identity/authentication/AuthenticationRepository.java
@@ -18,12 +18,11 @@ public class AuthenticationRepository {
     public User findUserByEmail(ServiceConfiguration configuration, String email) {
         final String sql = "SELECT id, first_name, last_name, email, password, created_at, updated_at FROM \"User\" WHERE email = :email";
 
-        val user = jdbiFactory.create(configuration)
+        return jdbiFactory.create(configuration)
                 .withHandle(handle -> handle.createQuery(sql)
-                        .bind("email", email)
-                        .mapToBean(User.class)
-                        .findFirst());
-
-        return user.orElseThrow(() -> new RuntimeException("Unable to find a user with those credentials"));
+                    .bind("email", email)
+                    .mapToBean(User.class)
+                    .findFirst()
+                    .orElse(null));
     }
 }


### PR DESCRIPTION
The throw here isn't needed because the null case is caught by the calling function and a proper auth error is thrown in such a case.
It was throwing 500 before, now it throws 400. 400 doesn't seem right, but it seems to be what the other services do (tested with Salesforce).